### PR TITLE
Bump version to 1.2.2

### DIFF
--- a/kpi/build.gradle.kts
+++ b/kpi/build.gradle.kts
@@ -38,7 +38,7 @@ android {
 @OptIn(org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi::class)
 kotlin {
     group = "com.kape.android"
-    version = "1.2.1-rc01"
+    version = "1.2.2"
 
     // Enable the default target hierarchy.
     // It's a template for all possible targets and their shared source sets hardcoded in the


### PR DESCRIPTION
## Summary

As per title, it bumps the version to `1.2.2`.

## Sanity Tests

N/A